### PR TITLE
x username format

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -113,9 +113,9 @@ export default function Home() {
                 <span className="underline underline-offset-4">
                   X Display Name
                 </span>{" "}
-                - Change your display name (not your handle) to:
+                - Change your display name on X (not your handle) to:
                 <div className="bg-mauve-3 dark:bg-mauvedark-3 p-6 rounded-lg border border-mauve-7 dark:border-mauvedark-7 mt-6 text-center">
-                  Your Name (@your_handle.bsky.social)
+                  Your Name 🦋 @your.bluesky.handle
                 </div>
               </li>
               <li>


### PR DESCRIPTION
Change the format of the X username to include the 🦋

<img width="673" alt="image" src="https://github.com/user-attachments/assets/2c7d7f04-d858-428d-814f-2a2851366625">

I prefer to use directly "🦋 @your.bluesky.handle", but I think it is better we recommend your version (+ the butterfly)