### PR TITLE
fix link in post goodbye step

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -120,7 +120,7 @@ export default function Home() {
               </li>
               <li>
                 <Link
-                  href="https://x.com/compose/post?text=🦋g"
+                  href="https://x.com/compose/post?text=🦋"
                   target="_blank"
                   rel="noopener"
                 >


### PR DESCRIPTION
Hey so I was checking out the website and I noticed that when I clicked on the link it would add a "g" after the 🦋 emoji - i was wonder if it's just a typo or it's like... intentional to make sure that the emoji get typed correctly in the tweet writer box. If not, here's a quick fix!