### PR TITLE
Replace Sky Follower Bridge chrome ext. link with homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -90,7 +90,7 @@ export default function Home() {
             <ol className="list-decimal list-outside flex flex-col gap-4 my-8 mx-4">
               <li>
                 <Link
-                  href="https://chromewebstore.google.com/detail/sky-follower-bridge/behhbpbpmailcnfbjagknjngnfdojpko?hl=en"
+                  href="https://skyfollowerbridge.com/"
                   target="_blank"
                   rel="noopener"
                 >


### PR DESCRIPTION
Sky Follower Bridge supports Firefox as well as Chrome, so linking to the extension's website with a button for both browsers would be an improvement. The original link on this Bluesky migration website also had the English language encoded in the url, which could lead to non-English users getting text in the wrong language.