### PR TITLE
Update link for sky-follower-bridge to the official site.

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -90,7 +90,7 @@ export default function Home() {
             <ol className="list-decimal list-outside flex flex-col gap-4 my-8 mx-4">
               <li>
                 <Link
-                  href="https://github.com/kawamataryo/sky-follower-bridge?tab=readme-ov-file#-installation"
+                  href="https://sky-follower-bridge-docs.vercel.app/"
                   target="_blank"
                   rel="noopener"
                 >


### PR DESCRIPTION
Thank you for publishing the wonderful transition guide. Your work is amazing!

I changed the link for the Sky follower bridge to the one from the official site.

https://sky-follower-bridge-docs.vercel.app/

There are no ads here!

<img width="1433" alt="CleanShot 2024-11-10 at 23 12 39@2x" src="https://github.com/user-attachments/assets/79d7068c-bff4-4d2e-a52b-608ef6133b67">

